### PR TITLE
set parents by context

### DIFF
--- a/core/model/modx/processors/element/tv/renders/mgr/input/superboxselect.php
+++ b/core/model/modx/processors/element/tv/renders/mgr/input/superboxselect.php
@@ -7,20 +7,24 @@
  */
 
 $modx->lexicon->load('tv_widget');
-$modx->smarty->assign('base_url',$this->xpdo->getOption('base_url'));
+$modx->smarty->assign('base_url', $this->xpdo->getOption('base_url'));
 
-$parents = $this->get('elements');
-
-$bindingsResult = $this->processBindings($this->get('elements'),$modx->resource->get('id'));
+$bindingsResult = $this->processBindings($this->get('elements'), $modx->resource->get('id'));
 $parents = $this->parseInputOptions($bindingsResult);
-if (empty($parents)) { $parents = array($modx->getOption('site_start',null,1)); }
+if (empty($parents)) {
+  $parents = array($modx->getOption('site_start', null, 1));
+} elseif (!is_numeric($parents[0])) {
+	$context = $modx->getObject('modContextSetting', array('context_key' => $modx->resource->get('context_key'), 'key' => $parents[0]));
+	$context = is_object($context) ? $context : $modx->getObject('modContextSetting', array('context_key' => 'web', 'key' => $parents[0]));
+	$parents = is_object($context) ? array($context->get('value')) : array($modx->getOption('site_start', null, 1));
+}
 
 $parents = implode(',', $parents);
 $values = str_replace('||', ',', $value);
-$remote_url = $modx->getOption('assets_url',null,'/assets/').'components/superboxselect/fetch_resources.php';
+$remote_url = $modx->getOption('assets_url', null, '/assets/').'components/superboxselect/fetch_resources.php';
 
-$this->xpdo->smarty->assign('assets_url',$modx->getOption('assets_url',null,'/assets/'));
-$this->xpdo->smarty->assign('parents',$parents);
-$this->xpdo->smarty->assign('values',$values);
-$this->xpdo->smarty->assign('remote_url',$remote_url);
+$this->xpdo->smarty->assign('assets_url', $modx->getOption('assets_url', null, '/assets/'));
+$this->xpdo->smarty->assign('parents', $parents);
+$this->xpdo->smarty->assign('values', $values);
+$this->xpdo->smarty->assign('remote_url', $remote_url);
 return $this->xpdo->smarty->fetch('element/tv/renders/input/superboxselect.tpl');


### PR DESCRIPTION
With this modifications you could set the superselectbox parent id by a context setting. You just have to insert the context setting name in the input options and create a context setting in each context you use the superboxselect.

Regards
Jako
