### PR TITLE
Added context/system settings replacement for template variable input option

### DIFF
--- a/core/model/modx/processors/element/tv/renders/mgr/input/superboxselect.php
+++ b/core/model/modx/processors/element/tv/renders/mgr/input/superboxselect.php
@@ -23,4 +23,6 @@ $this->xpdo->smarty->assign('assets_url',$modx->getOption('assets_url',null,'/as
 $this->xpdo->smarty->assign('parents',$parents);
 $this->xpdo->smarty->assign('values',$values);
 $this->xpdo->smarty->assign('remote_url',$remote_url);
+$this->xpdo->smarty->assign('resource_id', $this->modx->getOption('id', $_REQUEST, 0));
+
 return $this->xpdo->smarty->fetch('element/tv/renders/input/superboxselect.tpl');

--- a/manager/templates/default/element/tv/renders/input/superboxselect.tpl
+++ b/manager/templates/default/element/tv/renders/input/superboxselect.tpl
@@ -19,6 +19,7 @@ Ext.onReady(function() {
 		baseParams:{
 		    {/literal}
 		    parents: '{$parents}',
+		    resource_id: '{$resource_id}',
 			{literal}
 		}
 	});


### PR DESCRIPTION
Think you forgot my last pull request.

Another bug and fix: $modx->getChildIds seems to get not the right data in a multi context installation without setting the context key.
